### PR TITLE
Fix dockerfile so the build succeeds now.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
 
 COPY . .
 
-RUN pip3 install poetry && \
+RUN pip3 install poetry pyOpenSSL dsinternals && \
     poetry config virtualenvs.create false && \
     poetry install
 


### PR DESCRIPTION
Prior to these changes, the docker build would error out saying that dsinternals and pyOpenSSL were needed as well